### PR TITLE
Updated library to fully use Task infrastructure for scheduled functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ static async Task Main(string[] args)
     // .AtMonths(), .AtDays(), AtDaysOfWeek() ... etc
     .WithName("EveryTenSec") //Optional ID for your reference 
     .WithTimeZone(TimeZoneInfo.Utc) // Or string such as "America/Los_Angeles"
-    .Execute((e, token) => {
+    .Execute(async (e, token) => {
       if(!token.IsCancellationRequested)
         Console.WriteLine($"{e.TaskId}: Event intended for {e.TimeScheduledUtc:o} occurred at {e.TimeScheduledUtc:o}");
         return true; // Return success. Used by retry scenarios. 
@@ -37,12 +37,12 @@ static async Task Main(string[] args)
 
   var s2 = runtime.CreateSchedule()
     .ExecuteOnceAt(DateTimeOffset.UtcNow.AddSeconds(5))
-    .Execute((_, _) => { Console.WriteLine("Use ExecuteOnceAt to run this task in 5 seconds. Useful for retry scenarios."); return true; });
+    .Execute(async (_, _) => { Console.WriteLine("Use ExecuteOnceAt to run this task in 5 seconds. Useful for retry scenarios."); return true; });
 
   var s3 = runtime.CreateSchedule()
     .ExecuteOnceAt(DateTimeOffset.UtcNow.AddSeconds(1))
     .ExecuteAndRetry(
-      (e, _) => { 
+      async (e, _) => { 
           // Do something that may fail like a network call - catch & gracefully fail by returning false.
           // Exponential backoff task will retry up to MaxAttempts times. 
           return false; 
@@ -60,7 +60,7 @@ static async Task Main(string[] args)
   var s4 = runtime.CreateSchedule()
     .FromCron("0,20,40 * * * *")
     .WithName("Every20Sec") //Optional ID for your reference 
-    .Execute((e, token) => {
+    .Execute(async (e, token) => {
       if(!token.IsCancellationRequested)
         Console.WriteLine($"Load me from config and change me without recompiling!");
         return true; 

--- a/sample/Worker.cs
+++ b/sample/Worker.cs
@@ -10,11 +10,11 @@ namespace sample;
 
 public class ConsoleWriter : IScheduledTask
 {
-    public bool OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken _)
+    public async Task<bool> OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken _)
     {
         Console.WriteLine(String.Format("Event START at {0} on thread {1}", e.TimeScheduledUtc, System.Threading.Thread.CurrentThread.ManagedThreadId));
         // Sleep this thread for 12 seconds - it'll force the next invocation to occur on another thread. 
-        System.Threading.Thread.Sleep(12000);
+        await Task.Delay(12000);
         Console.WriteLine(String.Format("Event STOP at {0} on thread {1}", e.TimeScheduledUtc, System.Threading.Thread.CurrentThread.ManagedThreadId));
         return true;
     }
@@ -44,7 +44,7 @@ public class Worker : BackgroundService
         Runtime.CreateSchedule()
             .AtSeconds(0, 10, 20, 30, 40, 50)
             .WithName("EveryTenSec")
-            .Execute((e, token) => {
+            .Execute(async (e, token) => {
                 if(!token.IsCancellationRequested)
                     _logger.LogInformation($"{e.TaskId}: Event intended for {e.TimeScheduledUtc:o} occurred at {e.TimeSignaledUtc:o}");
                 return true;
@@ -52,7 +52,7 @@ public class Worker : BackgroundService
 
         // Unhandled exceptions need to be managed - see the handler in ctor 
         Runtime.CreateSchedule()
-            .Execute((e, token) => {
+            .Execute(async (e, token) => {
                 _logger.LogInformation("Execute once only, delete myself.");
                 e.ScheduleRule.AsActive(false);
                 throw new Exception("This is an unhandled exception in a task, handle it with TaskSchedulerRuntime.UnhandledScheduledTaskException.");
@@ -61,7 +61,7 @@ public class Worker : BackgroundService
         // Retry a task with exponential backoff. 
         Runtime.CreateSchedule()
             .ExecuteOnceAt(DateTimeOffset.UtcNow.AddSeconds(2))
-            .Execute(new ExponentialBackoffTask((_, _) =>
+            .Execute(new ExponentialBackoffTask(async (_, _) =>
             {
                 // Do something that may fail like make a network call.
                 // Graceful fail by catching the exception and returning false.

--- a/src/AnonymousScheduledTask.cs
+++ b/src/AnonymousScheduledTask.cs
@@ -5,6 +5,7 @@
  */
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using TaskSchedulerEngine;
 
 /// <summary>
@@ -12,14 +13,14 @@ using TaskSchedulerEngine;
 /// </summary>
 internal class AnonymousScheduledTask : IScheduledTask
 {
-    public AnonymousScheduledTask(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback)
+    public AnonymousScheduledTask(Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> callback)
     {
         Callback = callback;
     }
 
-    public Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> Callback { get; set; }
+    public Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> Callback { get; set; }
 
-    public bool OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
+    public Task<bool> OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
     {
         return Callback(e, c);
     }

--- a/src/ExponentialBackoffTask.cs
+++ b/src/ExponentialBackoffTask.cs
@@ -5,6 +5,7 @@
  */
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace TaskSchedulerEngine
 {
@@ -15,7 +16,7 @@ namespace TaskSchedulerEngine
     /// </summary>
     public class ExponentialBackoffTask : IScheduledTask
     {
-        public ExponentialBackoffTask(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback, int maxAttempts, int baseRetryInteravalSeconds)
+        public ExponentialBackoffTask(Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> callback, int maxAttempts, int baseRetryInteravalSeconds)
             : this(new RetryableTaskArgs(new AnonymousScheduledTask(callback), maxAttempts, baseRetryInteravalSeconds))
         {
         }
@@ -26,7 +27,7 @@ namespace TaskSchedulerEngine
 
         private RetryableTaskArgs _args;
 
-        public bool OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
+        public Task<bool> OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
         {
             //Factory pattern needs to create a new instance to manage the retry lifetime of this invocation 
             // If we didn't clone then future instances here would start from already having their retries "used up."

--- a/src/IScheduledTask.cs
+++ b/src/IScheduledTask.cs
@@ -4,6 +4,7 @@
  * https://github.com/pettijohn/TaskSchedulerEngine
  */
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace TaskSchedulerEngine
 {
@@ -15,6 +16,6 @@ namespace TaskSchedulerEngine
         /// <param name="e">Information about the scheduled time of task.</param>
         /// <param name="c">Allow graceful shutdown.</param>
         /// <returns>Optional success value; useful for e.g. retry scenarios.</returns>
-        bool OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c);
+        Task<bool> OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c);
     }
 }

--- a/src/RetryableTaskInvocation.cs
+++ b/src/RetryableTaskInvocation.cs
@@ -5,6 +5,7 @@
  */
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace TaskSchedulerEngine
 {
@@ -22,10 +23,10 @@ namespace TaskSchedulerEngine
         private object _lockObject = new Object();
         
 
-        public bool OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
+        public async Task<bool> OnScheduleRuleMatch(ScheduleRuleMatchEventArgs e, CancellationToken c)
         {
             // 0th invocation 
-            bool success = _args.Task.OnScheduleRuleMatch(e, c);
+            bool success = await _args.Task.OnScheduleRuleMatch(e, c);
             lock (_lockObject) //thread safety 
             {
                 // Compare against MaxAttempts - 1. 

--- a/src/ScheduleEvaluationOptimized.cs
+++ b/src/ScheduleEvaluationOptimized.cs
@@ -133,13 +133,13 @@ namespace TaskSchedulerEngine
 
             //Perform a bitwise AND on the compareValue and this. If the result is non-zero, then there is a match.
             //1 << x is the same as 2^^x, just faster since it's not a floating point op.
-            return (((1L << (timeToEvaluate.Year - ScheduleRule.MinYear) & this.Year) != 0)
+            return (((1L << (timeToEvaluate.Year - ScheduleRule.MinYear)) & this.Year) != 0)
                 && ((1L << timeToEvaluate.Month & this.Month) != 0)
                 && ((1L << timeToEvaluate.Day & this.DayOfMonth) != 0)
                 && ((1L << (int)timeToEvaluate.DayOfWeek & this.DayOfWeek) != 0)
                 && ((1L << timeToEvaluate.Hour & this.Hour) != 0)
                 && ((1L << timeToEvaluate.Minute & this.Minute) != 0)
-                && ((1L << timeToEvaluate.Second & this.Second) != 0));
+                && ((1L << timeToEvaluate.Second & this.Second) != 0);
         }
 
     }

--- a/src/ScheduleRule.cs
+++ b/src/ScheduleRule.cs
@@ -273,11 +273,24 @@ namespace TaskSchedulerEngine
             return this;
         }
 
+        /// <summary>
+        /// Execute a task with exponential backoff algorithm. See ExponentialBackoffTask for details. 
+        /// </summary>
+        public ScheduleRule ExecuteAndRetry(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback, int maxAttempts, int baseRetryIntervalSeconds)
+        {
+            return ExecuteAndRetry(async (e, ct) => callback(e, ct), maxAttempts, baseRetryIntervalSeconds);
+        }
+
         public ScheduleRule Execute(Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> callback)
         {
             Task = new AnonymousScheduledTask(callback);
             if(Runtime != null) Runtime.UpdateSchedule(this);
             return this;
+        }
+
+        public ScheduleRule Execute(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback)
+        {
+            return Execute(async (e, ct) => callback(e, ct));
         }
 
         public ScheduleRule Execute(IScheduledTask taskInstance)

--- a/src/ScheduleRule.cs
+++ b/src/ScheduleRule.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 
 [assembly: InternalsVisibleToAttribute("TaskSchedulerEngineTests")]
 
@@ -265,14 +266,14 @@ namespace TaskSchedulerEngine
         /// <summary>
         /// Execute a task with exponential backoff algorithm. See ExponentialBackoffTask for details. 
         /// </summary>
-        public ScheduleRule ExecuteAndRetry(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback, int maxAttempts, int baseRetryIntervalSeconds)
+        public ScheduleRule ExecuteAndRetry(Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> callback, int maxAttempts, int baseRetryIntervalSeconds)
         {
             Task = new ExponentialBackoffTask(callback, maxAttempts, baseRetryIntervalSeconds);
             if(Runtime != null) Runtime.UpdateSchedule(this);
             return this;
         }
 
-        public ScheduleRule Execute(Func<ScheduleRuleMatchEventArgs, CancellationToken, bool> callback)
+        public ScheduleRule Execute(Func<ScheduleRuleMatchEventArgs, CancellationToken, Task<bool>> callback)
         {
             Task = new AnonymousScheduledTask(callback);
             if(Runtime != null) Runtime.UpdateSchedule(this);

--- a/test/ScheduleRuleTest.cs
+++ b/test/ScheduleRuleTest.cs
@@ -56,7 +56,7 @@ namespace SchedulerEngineRuntimeTests
                 .AtYears(DateTime.Now.Year)
                 .WithName("Optional name/ID parameter")
                 .WithUtc()
-                .Execute(async (e, c) => { return true; }); //noop callback, as callback cannot be null
+                .Execute((e, c) => { return true; }); //noop callback, as callback cannot be null
 
             var evalOptimized = new ScheduleEvaluationOptimized(rule);
 
@@ -74,7 +74,7 @@ namespace SchedulerEngineRuntimeTests
                 .ExecuteOnceAt(executeTime)
                 .WithName("Optional name/ID parameter")
                 .WithUtc()
-                .Execute(async (e, c) => { return true; }); //noop callback, as callback cannot be null
+                .Execute((e, c) => { return true; }); //noop callback, as callback cannot be null
 
             var evalOptimized = new ScheduleEvaluationOptimized(rule);
 
@@ -252,7 +252,7 @@ namespace SchedulerEngineRuntimeTests
                 .AtSeconds(0)
                 .AtMinutes(0)
                 .AtHours(11)
-                .Execute(async (a,b) => true);
+                .Execute((a, b) => true);
 
             Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.Zero)));
 

--- a/test/ScheduleRuleTest.cs
+++ b/test/ScheduleRuleTest.cs
@@ -56,7 +56,7 @@ namespace SchedulerEngineRuntimeTests
                 .AtYears(DateTime.Now.Year)
                 .WithName("Optional name/ID parameter")
                 .WithUtc()
-                .Execute((e, c) => { return true; }); //noop callback, as callback cannot be null
+                .Execute(async (e, c) => { return true; }); //noop callback, as callback cannot be null
 
             var evalOptimized = new ScheduleEvaluationOptimized(rule);
 
@@ -74,7 +74,7 @@ namespace SchedulerEngineRuntimeTests
                 .ExecuteOnceAt(executeTime)
                 .WithName("Optional name/ID parameter")
                 .WithUtc()
-                .Execute((e, c) => { return true; }); //noop callback, as callback cannot be null
+                .Execute(async (e, c) => { return true; }); //noop callback, as callback cannot be null
 
             var evalOptimized = new ScheduleEvaluationOptimized(rule);
 
@@ -252,7 +252,7 @@ namespace SchedulerEngineRuntimeTests
                 .AtSeconds(0)
                 .AtMinutes(0)
                 .AtHours(11)
-                .Execute((a,b) => true);
+                .Execute(async (a,b) => true);
 
             Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.Zero)));
 

--- a/test/ScheduleRuleTest.cs
+++ b/test/ScheduleRuleTest.cs
@@ -50,17 +50,17 @@ namespace SchedulerEngineRuntimeTests
                 .AtHours(0, 23)
                 .AtMinutes(0)
                 .AtSeconds(0)
-                .AtDaysOfWeek(3)
+                .AtDaysOfWeek((int)new DateTime(DateTime.Now.Year, 11, 30).DayOfWeek)
                 .AtDaysOfMonth(30)
                 .AtMonths(11)
-                .AtYears(2022)
+                .AtYears(DateTime.Now.Year)
                 .WithName("Optional name/ID parameter")
                 .WithUtc()
                 .Execute((e, c) => { return true; }); //noop callback, as callback cannot be null
 
             var evalOptimized = new ScheduleEvaluationOptimized(rule);
 
-            var evalTime = new DateTimeOffset(2022, 11, 30, 23, 0, 0, TimeSpan.Zero);
+            var evalTime = new DateTimeOffset(DateTime.Now.Year, 11, 30, 23, 0, 0, TimeSpan.Zero);
 
             var testResult = evalOptimized.EvaluateRuleMatch(evalTime);
             Assert.IsTrue(testResult);
@@ -69,7 +69,7 @@ namespace SchedulerEngineRuntimeTests
         [TestMethod]
         public void ExecuteOnceTest()
         {
-            var executeTime = new DateTimeOffset(2022, 11, 30, 23, 0, 0, TimeSpan.Zero);
+            var executeTime = new DateTimeOffset(DateTime.Now.Year, 11, 30, 23, 0, 0, TimeSpan.Zero);
             var rule = new ScheduleRule()
                 .ExecuteOnceAt(executeTime)
                 .WithName("Optional name/ID parameter")
@@ -254,18 +254,18 @@ namespace SchedulerEngineRuntimeTests
                 .AtHours(11)
                 .Execute((a,b) => true);
 
-            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(2023, 6, 19, 11, 0, 0, TimeSpan.Zero)));
+            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.Zero)));
 
             // Evaluate against an offset - rule still UTC
-            Assert.IsFalse(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(2023, 6, 19, 11, 0, 0, TimeSpan.FromHours(-8))));
-            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(2023, 6, 19, 3, 0, 0, TimeSpan.FromHours(-8))));
+            Assert.IsFalse(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.FromHours(-8))));
+            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 3, 0, 0, TimeSpan.FromHours(-8))));
 
             // Adjust rule to a different time zone
             // PST is -8 in winter and -7 in summer
             var pst = TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles");
             rule.WithTimeZone(pst);
-            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(2023, 6, 19, 11, 0, 0, TimeSpan.FromHours(-7))));
-            Assert.IsFalse(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(2023, 6, 19, 11, 0, 0, TimeSpan.Zero)));
+            Assert.IsTrue(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.FromHours(-7))));
+            Assert.IsFalse(new ScheduleEvaluationOptimized(rule).EvaluateRuleMatch(new DateTimeOffset(DateTime.Now.Year, 6, 19, 11, 0, 0, TimeSpan.Zero)));
         }
     }
 }


### PR DESCRIPTION
The usage pattern had scheduled tasks as sync functions, which I believe to be a leftover from the pattern of the original library from 2010. 

By changing the IScheduledTask function to return Task<bool> then scheduled functions can simply be sync or async cleanly. This also allows for much cleaner semantics around cancellation token. 
For example:
```C#
   schedule
       .AtMinutes(0,15,30,45)
       .Execute(async (e, cancellationToken) =>
       {
                results = await httpClient.GetAsync(..., cancellationToken);
                return true;
       });
```

Synchronous tasks can simply be written like this:
```C#
   schedule
       .AtMinutes(0,15,30,45)
       .Execute(async (e, cancellationToken) =>
       {
                i++;
                return true;
       });
```
or if you don't want to use the async machinery:
```C#
   schedule
       .AtMinutes(0,15,30,45)
       .Execute((e, cancellationToken) =>
       {
                i++;
                return Task.FromResult(true);
       });
```

To handle cancellations you put a try catch around async APIs that take a cancellation token, like this:
```C#
   schedule
       .AtMinutes(0,15,30,45)
       .Execute(async (e, cancellationToken) =>
       {
          try 
          {
                results = await httpClient.GetAsync(..., cancellationToken);
                return true;
          }  
         catch(Exception)
       {
            return false;
       } 
   });
```

Changes are
* Fixed bug in calculation of bit field for years
* Updated unit tests to use years which are compatible (library only allows year dates to be this year - 1)
* Changed signature of IScheduledTask/Execute to return Task<bool> instead of bool.
* Updated unit tests to use async pattern 

