### PR TITLE
Expanded existing ExecuteOnceAt() signature 

### DIFF
--- a/src/ScheduleRule.cs
+++ b/src/ScheduleRule.cs
@@ -248,80 +248,6 @@ namespace TaskSchedulerEngine
             return s;
         }
 
-        /// <summary>
-        /// Execute once for every year, on first second of first minute of first hour of first day of first month of year
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAYear()
-        {
-            return this.AtMonths(1)
-                .ExecuteOnceAMonth();
-        }
-
-        /// <summary>
-        /// Execute once for a month, on first second of first minute of first hour of first day of month 
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAMonth()
-        {
-            return this.AtDaysOfMonth(1)
-                .ExecuteOnceADay();
-        }
-
-        /// <summary>
-        /// Execute once for a month, on first second of first minute of first hour of first day of month 
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAWeek()
-        {
-            return this.AtDaysOfWeek(0)
-                .ExecuteOnceADay();
-        }
-
-        /// <summary>
-        /// Execute once a day, on first second of first minute of day
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceADay()
-        {
-            return this.AtHours(0)
-                .ExecuteOnceAnHour();
-        }
-
-        /// <summary>
-        /// Execute once for each hour specified, on first second of first minute of hour
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAnHour()
-        {
-            return this.AtMinutes(0)
-                .ExecuteOnceAMinute();
-        }
-
-        /// <summary>
-        /// Execute once for a minute specified, on first second of the minute
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAMinute()
-        {
-            return this.AtSeconds(0);
-        }
-
-        /// <summary>
-        /// Execute once for a minute specified, on first second of the minute
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceASecond()
-        {
-            return this.AtSeconds(Enumerable.Range(0, 60).ToArray());
-        }
 
 
         /// <summary>
@@ -329,10 +255,14 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtYears(params int[] value)
+        public ScheduleRule ExecuteEveryYear(params int[] value)
         {
             return this.AtYears(value)
-                .ExecuteOnceAYear();
+                .AtMonths(1)
+                .AtDaysOfMonth(1)
+                .AtHours(0)
+                .AtMinutes(0)
+                .AtSeconds(0);
         }
 
         /// <summary>
@@ -340,10 +270,14 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtMonths(params int[] value)
+        public ScheduleRule ExecuteEveryMonth(params int[] value)
         {
-            return this.AtMonths(value)
-                .ExecuteOnceAMonth();
+            return this
+                .AtMonths(value)
+                .AtDaysOfMonth(1)
+                .AtHours(0)
+                .AtMinutes(0)
+                .AtSeconds(0);
         }
 
 
@@ -352,10 +286,13 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtDaysOfMonth(params int[] value)
+        public ScheduleRule ExecuteEveryDayOfMonth(params int[] value)
         {
-            return this.AtDaysOfMonth(value)
-                .ExecuteOnceADay();
+            return this
+                .AtDaysOfMonth(value)
+                .AtHours(0)
+                .AtMinutes(0)
+                .AtSeconds(0);
         }
 
         /// <summary>
@@ -363,21 +300,12 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtDaysOfWeek(params DayOfWeek[] value)
-        {
-            return this.AtDaysOfWeek(value.Select(v => (int)v).ToArray())
-                .ExecuteOnceADay();
-        }
-
-        /// <summary>
-        /// Execute once for each day of week specified, on first second of first minute of first hour of day 
-        /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtDaysOfWeek(params int[] value)
+        public ScheduleRule ExecuteEveryDayOfWeek(params int[] value)
         {
             return this.AtDaysOfWeek(value)
-                .ExecuteOnceADay();
+                .AtHours(0)
+                .AtMinutes(0)
+                .AtSeconds(0);
         }
 
         /// <summary>
@@ -385,10 +313,11 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtHours(params int[] value)
+        public ScheduleRule ExecuteEveryHour(params int[] value)
         {
             return this.AtHours(value)
-                .ExecuteOnceAnHour();
+                .AtMinutes(0)
+                .AtSeconds(0);
         }
 
         /// <summary>
@@ -396,10 +325,10 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtMinutes(params int[] value)
+        public ScheduleRule ExecuteEveryMinute(params int[] value)
         {
             return this.AtMinutes(value)
-                .ExecuteOnceAMinute();
+                .AtSeconds(0);
         }
 
         /// <summary>
@@ -407,9 +336,9 @@ namespace TaskSchedulerEngine
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-        public ScheduleRule ExecuteOnceAtSeconds(params int[] value)
+        public ScheduleRule ExecuteEverySecond(params int[] value)
         {
-            return this.AtSeconds(value);
+            return this.AtSeconds(value ?? Enumerable.Range(0,60).ToArray());
         }
 
 

--- a/src/ScheduleRule.cs
+++ b/src/ScheduleRule.cs
@@ -248,6 +248,171 @@ namespace TaskSchedulerEngine
             return s;
         }
 
+        /// <summary>
+        /// Execute once for every year, on first second of first minute of first hour of first day of first month of year
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAYear()
+        {
+            return this.AtMonths(1)
+                .ExecuteOnceAMonth();
+        }
+
+        /// <summary>
+        /// Execute once for a month, on first second of first minute of first hour of first day of month 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAMonth()
+        {
+            return this.AtDaysOfMonth(1)
+                .ExecuteOnceADay();
+        }
+
+        /// <summary>
+        /// Execute once for a month, on first second of first minute of first hour of first day of month 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAWeek()
+        {
+            return this.AtDaysOfWeek(0)
+                .ExecuteOnceADay();
+        }
+
+        /// <summary>
+        /// Execute once a day, on first second of first minute of day
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceADay()
+        {
+            return this.AtHours(0)
+                .ExecuteOnceAnHour();
+        }
+
+        /// <summary>
+        /// Execute once for each hour specified, on first second of first minute of hour
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAnHour()
+        {
+            return this.AtMinutes(0)
+                .ExecuteOnceAMinute();
+        }
+
+        /// <summary>
+        /// Execute once for a minute specified, on first second of the minute
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAMinute()
+        {
+            return this.AtSeconds(0);
+        }
+
+        /// <summary>
+        /// Execute once for a minute specified, on first second of the minute
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceASecond()
+        {
+            return this.AtSeconds(Enumerable.Range(0, 60).ToArray());
+        }
+
+
+        /// <summary>
+        /// Execute once for each year specified, on first second of first minute of first hour of first day of first month of year
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtYears(params int[] value)
+        {
+            return this.AtYears(value)
+                .ExecuteOnceAYear();
+        }
+
+        /// <summary>
+        /// Execute once for each month specified, on first second of first minute of first hour of first day month 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtMonths(params int[] value)
+        {
+            return this.AtMonths(value)
+                .ExecuteOnceAMonth();
+        }
+
+
+        /// <summary>
+        /// Execute once for day of month specified, on first second of first minute of day
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtDaysOfMonth(params int[] value)
+        {
+            return this.AtDaysOfMonth(value)
+                .ExecuteOnceADay();
+        }
+
+        /// <summary>
+        /// Execute once for each day of week specified, on first second of first minute of first hour of day 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtDaysOfWeek(params DayOfWeek[] value)
+        {
+            return this.AtDaysOfWeek(value.Select(v => (int)v).ToArray())
+                .ExecuteOnceADay();
+        }
+
+        /// <summary>
+        /// Execute once for each day of week specified, on first second of first minute of first hour of day 
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtDaysOfWeek(params int[] value)
+        {
+            return this.AtDaysOfWeek(value)
+                .ExecuteOnceADay();
+        }
+
+        /// <summary>
+        /// Execute once for each hour specified, on first second of first minute of hour
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtHours(params int[] value)
+        {
+            return this.AtHours(value)
+                .ExecuteOnceAnHour();
+        }
+
+        /// <summary>
+        /// Execute once for each minute specified, on first second of minute
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtMinutes(params int[] value)
+        {
+            return this.AtMinutes(value)
+                .ExecuteOnceAMinute();
+        }
+
+        /// <summary>
+        /// Execute once for each second specified
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public ScheduleRule ExecuteOnceAtSeconds(params int[] value)
+        {
+            return this.AtSeconds(value);
+        }
+
+
         public DateTimeOffset Expiration { get; private set; } = DateTimeOffset.MaxValue;
         /// <summary>
         /// Time after which the task shall be deleted from the scheduler. 

--- a/test/ScheduleRuleTest.cs
+++ b/test/ScheduleRuleTest.cs
@@ -12,7 +12,7 @@ namespace SchedulerEngineRuntimeTests
     public class ScheduleRuleTest
     {
         public ScheduleRuleTest()
-        {}
+        { }
 
         [TestMethod]
         public void ParseIntArrayToBitfieldTest()
@@ -67,7 +67,7 @@ namespace SchedulerEngineRuntimeTests
         }
 
         [TestMethod]
-        public void ExecuteOnceTest()
+        public void ExecuteOnceAtTest()
         {
             var executeTime = new DateTimeOffset(DateTime.Now.Year, 11, 30, 23, 0, 0, TimeSpan.Zero);
             var rule = new ScheduleRule()
@@ -90,6 +90,293 @@ namespace SchedulerEngineRuntimeTests
             testResult = evalOptimized.EvaluateRuleMatch(evalTime.AddYears(1));
             Assert.IsFalse(testResult);
         }
+
+        [TestMethod]
+        public void ExecuteOnceAtYearsTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtYears(2024, 2025)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddYears(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddYears(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAtMonthsTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtMonths(1, 2)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+
+        [TestMethod]
+        public void ExecuteOnceAtDaysOfMonthTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtDaysOfMonth(1, 2)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+        [TestMethod]
+        public void ExecuteOnceAtDaysOfWeekTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtDaysOfWeek(1, 2)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAtDaysOfWeekEnumTest()
+        {
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtDaysOfWeek(evalTime.DayOfWeek)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+
+        [TestMethod]
+        public void ExecuteOnceAtHoursTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtHours(0, 1)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAtMinutesTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtMinutes(0, 1)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(2)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAtSecondsText()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAtSeconds(0, 1)
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for(int i=0; i <10;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(i)
+                    .AddMonths(i)
+                    .AddDays(i)
+                    .AddHours(i)
+                    .AddMinutes(i)));
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(2)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAYearTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAYear()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int year = 0; year < 10; year++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAMonthTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAMonth()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int inc = 0; inc < 12; inc++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(inc)
+                    .AddMonths(inc)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+        [TestMethod]
+        public void ExecuteOnceADayTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceADay()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int inc = 0; inc < 12; inc++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(inc)
+                    .AddMonths(inc)
+                    .AddDays(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAWeekTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAWeek()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 7, 0, 0, 0, TimeSpan.Zero);
+            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
+            for(int i=1; i< 7;i++)
+                Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(i)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceAnHourTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAnHour()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int inc = 0; inc < 60; inc++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(inc)
+                    .AddMonths(inc % 12)
+                    .AddDays(inc % 28)
+                    .AddHours(inc)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        
+        [TestMethod]
+        public void ExecuteOnceAMinuteTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceAMinute()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int inc = 0; inc < 60; inc++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(inc)
+                    .AddMonths(inc % 12)
+                    .AddDays(inc % 28)
+                    .AddHours(inc)
+                    .AddMinutes(inc)));
+            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+        }
+
+        [TestMethod]
+        public void ExecuteOnceASecondTest()
+        {
+            var rule = new ScheduleRule()
+                .ExecuteOnceASecond()
+                .WithUtc()
+                .Execute((e, c) => { return true; });
+
+            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (int inc = 0; inc < 60; inc++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
+                    .AddYears(inc)
+                    .AddMonths(inc % 12)
+                    .AddDays(inc % 28)
+                    .AddHours(inc)
+                    .AddMinutes(inc)
+                    .AddSeconds(inc)));
+        }
+
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]

--- a/test/ScheduleRuleTest.cs
+++ b/test/ScheduleRuleTest.cs
@@ -92,14 +92,13 @@ namespace SchedulerEngineRuntimeTests
         }
 
         [TestMethod]
-        public void ExecuteOnceAtYearsTest()
+        public void ExecuteEveryYearsTest()
         {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtYears(2024, 2025)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryYear(2024, 2025)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
+                .Execute((e, c) => { return true; }));
 
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddYears(1)));
@@ -109,17 +108,22 @@ namespace SchedulerEngineRuntimeTests
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryYear()
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for(int i=0; i<10;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddYears(i)));
         }
 
         [TestMethod]
-        public void ExecuteOnceAtMonthsTest()
+        public void ExecuteEveryMonthsTest()
         {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtMonths(1, 2)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryMonth(1, 2)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(1)));
@@ -128,18 +132,23 @@ namespace SchedulerEngineRuntimeTests
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryMonth()
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for (int i = 0; i < 12; i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(i)));
         }
 
 
         [TestMethod]
-        public void ExecuteOnceAtDaysOfMonthTest()
+        public void ExecuteEveryDaysOfMonthTest()
         {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtDaysOfMonth(1, 2)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryDayOfMonth(1, 2)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
@@ -147,16 +156,22 @@ namespace SchedulerEngineRuntimeTests
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-        [TestMethod]
-        public void ExecuteOnceAtDaysOfWeekTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtDaysOfWeek(1, 2)
-                .WithUtc()
-                .Execute((e, c) => { return true; });
 
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryDayOfMonth()
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for(int i=0; i<28;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(i)));
+        }
+
+        [TestMethod]
+        public void ExecuteEveryDaysOfWeekTest()
+        {
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryDayOfWeek(1, 2)
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
@@ -164,69 +179,65 @@ namespace SchedulerEngineRuntimeTests
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryDayOfWeek(1, 2)
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for(int i=0; i <7;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
         }
 
         [TestMethod]
-        public void ExecuteOnceAtDaysOfWeekEnumTest()
+        public void ExecuteEveryHoursTest()
         {
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtDaysOfWeek(evalTime.DayOfWeek)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryHour(0, 1)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(2)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-
-        [TestMethod]
-        public void ExecuteOnceAtHoursTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtHours(0, 1)
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(2)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryHour()
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for(int i=0;i<60;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(i)));
         }
 
         [TestMethod]
-        public void ExecuteOnceAtMinutesTest()
+        public void ExecuteEveryMinutesTest()
         {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtMinutes(0, 1)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryMinute(0, 1)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(2)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEveryMinute()
+                .WithUtc()
+                .Execute((e, c) => { return true; }));
+            for(int i=0;i<60;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(i)));
         }
 
         [TestMethod]
-        public void ExecuteOnceAtSecondsText()
+        public void ExecuteEverySecondsText()
         {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAtSeconds(0, 1)
+            var evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                .ExecuteEverySecond(0, 1)
                 .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
+                .Execute((e, c) => { return true; }));
             var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
             for(int i=0; i <10;i++)
                 Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
@@ -237,145 +248,15 @@ namespace SchedulerEngineRuntimeTests
                     .AddMinutes(i)));
             Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
             Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(2)));
+
+            evalOptimized = new ScheduleEvaluationOptimized(new ScheduleRule()
+                            .ExecuteEverySecond()
+                            .WithUtc()
+                            .Execute((e, c) => { return true; }));
+            for(int i = 0; i <10;i++)
+                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(i)));
         }
 
-        [TestMethod]
-        public void ExecuteOnceAYearTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAYear()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int year = 0; year < 10; year++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMonths(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-        [TestMethod]
-        public void ExecuteOnceAMonthTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAMonth()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int inc = 0; inc < 12; inc++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(inc)
-                    .AddMonths(inc)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-        [TestMethod]
-        public void ExecuteOnceADayTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceADay()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int inc = 0; inc < 12; inc++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(inc)
-                    .AddMonths(inc)
-                    .AddDays(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-        [TestMethod]
-        public void ExecuteOnceAWeekTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAWeek()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 7, 0, 0, 0, TimeSpan.Zero);
-            Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime));
-            for(int i=1; i< 7;i++)
-                Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddDays(i)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddHours(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-        [TestMethod]
-        public void ExecuteOnceAnHourTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAnHour()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int inc = 0; inc < 60; inc++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(inc)
-                    .AddMonths(inc % 12)
-                    .AddDays(inc % 28)
-                    .AddHours(inc)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddMinutes(1)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-        
-        [TestMethod]
-        public void ExecuteOnceAMinuteTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceAMinute()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int inc = 0; inc < 60; inc++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(inc)
-                    .AddMonths(inc % 12)
-                    .AddDays(inc % 28)
-                    .AddHours(inc)
-                    .AddMinutes(inc)));
-            Assert.IsFalse(evalOptimized.EvaluateRuleMatch(evalTime.AddSeconds(1)));
-        }
-
-        [TestMethod]
-        public void ExecuteOnceASecondTest()
-        {
-            var rule = new ScheduleRule()
-                .ExecuteOnceASecond()
-                .WithUtc()
-                .Execute((e, c) => { return true; });
-
-            var evalOptimized = new ScheduleEvaluationOptimized(rule);
-            var evalTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
-            for (int inc = 0; inc < 60; inc++)
-                Assert.IsTrue(evalOptimized.EvaluateRuleMatch(evalTime
-                    .AddYears(inc)
-                    .AddMonths(inc % 12)
-                    .AddDays(inc % 28)
-                    .AddHours(inc)
-                    .AddMinutes(inc)
-                    .AddSeconds(inc)));
-        }
 
 
         [TestMethod]


### PR DESCRIPTION
Expanded on existing ExecuteOnceAt() signature to allow expressive fluent style for floor or remainder values.

Methods to apply floor for time segments
* ExecuteOnceAYear()
* ExecuteOnceAMonth()
* ExecuteOnceAWeek()
* ExecuteOnceADay()
* ExecuteOnceAnHour()
* ExecuteOnceAMinute()
* ExecuteOnceASecond()

``` ExecuteOnceAnHour()``` is effectively ```.AtMinutes(0).AtSeconds(0)```

Then there are specialized methods like this:
* ExecuteOnceAtYears(...)
* ExecuteOnceAtMonths(...)
* ExecuteOnceAtDaysOfMonth(...)
* ExecuteOnceAtDaysOfWeek(...)
* ExecuteOnceAtHours(...)
* ExecuteOnceAtMinutes(...)
* ExecuteOnceAtSeconds(...)

```ExecuteOnceAtHours(1,3)``` is effectively ```.AtHours(1,3).ExecuteOnceAnHour()```

Added unit tests for all new methods.

NOTE: This in no way changes the behavior of the existing AtXXX() methods. This also builds on the existing method pattern of ExecuteOnceAt(). I think this is a nice way to enable the ease of use I was wanting without breaking or impeding the power you already have.
